### PR TITLE
Fixed entry tests

### DIFF
--- a/src/filesystem/tasks/worker.rs
+++ b/src/filesystem/tasks/worker.rs
@@ -72,7 +72,11 @@ impl<T: StorageIO> FilesystemWorker<T> {
                 let page_number = if len > FilesystemHeader::LENGTH as u64 {
                     let total_pages = (len - FilesystemHeader::LENGTH as u64) / (PageHeader::LENGTH as u64 + self.header.page_size);
 
-                    total_pages as u32
+                    if total_pages * (PageHeader::LENGTH as u64 + self.header.page_size) < (len - FilesystemHeader::LENGTH as u64) {
+                        total_pages as u32 + 1
+                    } else {
+                        total_pages as u32
+                    }
                 } else {
                     0
                 };


### PR DESCRIPTION
- Fix the next() function to not skip the last element
- Actually create the page in the tests
- Fix off by one error in the entry.rs tests.
- Sanity check in worker.rs